### PR TITLE
ci: add github action to run short tests

### DIFF
--- a/.github/workflows/short-tests.yml
+++ b/.github/workflows/short-tests.yml
@@ -1,0 +1,22 @@
+name: Run short tests
+
+on:
+  push:
+    branches:
+      - main
+  pull_request:
+
+jobs:
+  test:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+
+      - name: Set up Go
+        uses: actions/setup-go@v5
+        with:
+          go-version: '1.22'
+
+      - name: Run tests
+        run: go test -short ./...


### PR DESCRIPTION
This change adds a GitHub Action that runs the short tests on every push to main and on every pull request.

Fixes: #11