### PR TITLE
feat: add merge command

### DIFF
--- a/cmd/merge.go
+++ b/cmd/merge.go
@@ -1,0 +1,90 @@
+package cmd
+
+import (
+	"encoding/csv"
+	"log"
+	"os"
+
+	"github.com/spf13/cobra"
+)
+
+var (
+	file1 string
+	file2 string
+	out   string
+)
+
+var mergeCmd = &cobra.Command{
+	Use:   "merge",
+	Short: "Merge two CSV files.",
+	Long:  `Merge two CSV files based on a common column.`,
+	Run: func(cmd *cobra.Command, args []string) {
+		if err := runMerge(file1, file2, out); err != nil {
+			log.Fatal(err)
+		}
+	},
+}
+
+func runMerge(file1, file2, out string) error {
+	f1, err := os.Open(file1)
+	if err != nil {
+		return err
+	}
+	defer f1.Close()
+
+	r1 := csv.NewReader(f1)
+	records1, err := r1.ReadAll()
+	if err != nil {
+		return err
+	}
+
+	f2, err := os.Open(file2)
+	if err != nil {
+		return err
+	}
+	defer f2.Close()
+
+	r2 := csv.NewReader(f2)
+	records2, err := r2.ReadAll()
+	if err != nil {
+		return err
+	}
+
+	header1 := records1[0]
+	header2 := records2[0]
+	mergedHeader := append(header1, header2[1:]...)
+
+	recordsMap := make(map[string][]string)
+	for _, record := range records1[1:] {
+		recordsMap[record[0]] = record
+	}
+
+	var mergedRecords [][]string
+	mergedRecords = append(mergedRecords, mergedHeader)
+
+	for _, record2 := range records2[1:] {
+		prNumber := record2[0]
+		if record1, ok := recordsMap[prNumber]; ok {
+			mergedRecord := append(record1, record2[1:]...)
+			mergedRecords = append(mergedRecords, mergedRecord)
+		}
+	}
+
+	outFile, err := os.Create(out)
+	if err != nil {
+		return err
+	}
+	defer outFile.Close()
+
+	w := csv.NewWriter(outFile)
+	return w.WriteAll(mergedRecords)
+}
+
+func init() {
+	rootCmd.AddCommand(mergeCmd)
+	mergeCmd.Flags().StringVar(&file1, "file1", "", "First CSV file")
+	mergeCmd.Flags().StringVar(&file2, "file2", "", "Second CSV file")
+	mergeCmd.Flags().StringVar(&out, "out", "merged.csv", "Output CSV file")
+	mergeCmd.MarkFlagRequired("file1")
+	mergeCmd.MarkFlagRequired("file2")
+}

--- a/cmd/merge_test.go
+++ b/cmd/merge_test.go
@@ -1,13 +1,57 @@
 package cmd
 
 import (
+	"encoding/csv"
+	"os"
 	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
 
-func TestRebaseMerge(t *testing.T) {
-	t.Skip("skipping test, not implemented yet")
-}
+func TestMerge(t *testing.T) {
+	file1, err := os.CreateTemp("", "file1.csv")
+	require.NoError(t, err)
+	defer os.Remove(file1.Name())
 
-func TestSquashMerge(t *testing.T) {
-	t.Skip("skipping test, not implemented yet")
+	w1 := csv.NewWriter(file1)
+	require.NoError(t, w1.WriteAll([][]string{
+		{"pr_number", "title"},
+		{"1", "title1"},
+		{"2", "title2"},
+	}))
+	w1.Flush()
+
+	file2, err := os.CreateTemp("", "file2.csv")
+	require.NoError(t, err)
+	defer os.Remove(file2.Name())
+
+	w2 := csv.NewWriter(file2)
+	require.NoError(t, w2.WriteAll([][]string{
+		{"pr_number", "author"},
+		{"1", "author1"},
+		{"3", "author3"},
+	}))
+	w2.Flush()
+
+	outFile, err := os.CreateTemp("", "out.csv")
+	require.NoError(t, err)
+	defer os.Remove(outFile.Name())
+
+	err = runMerge(file1.Name(), file2.Name(), outFile.Name())
+	require.NoError(t, err)
+
+	f, err := os.Open(outFile.Name())
+	require.NoError(t, err)
+	defer f.Close()
+
+	r := csv.NewReader(f)
+	records, err := r.ReadAll()
+	require.NoError(t, err)
+
+	expected := [][]string{
+		{"pr_number", "title", "author"},
+		{"1", "title1", "author1"},
+	}
+	assert.Equal(t, expected, records)
 }


### PR DESCRIPTION
This change adds a `merge` command to the CLI. This command can be used to merge two CSV files based on the `pr_number` column.

Fixes: #7