### PR TITLE
feat: Add vulnerability scanning

### DIFF
--- a/application_test.go
+++ b/application_test.go
@@ -18,10 +18,16 @@ func rungo(t *testing.T, args ...string) {
 	}
 }
 
+func TestVulnerabilityCheck(t *testing.T) {
+	if testing.Short() {
+		t.Skip("skipping vulnerability check in short mode.")
+	}
+	rungo(t, "run", "golang.org/x/vuln/cmd/govulncheck@latest", "./...")
+}
+
 func TestStaticAnalysis(t *testing.T) {
 	if testing.Short() {
 		t.Skip("skipping static analysis in short mode.")
 	}
-	//rungo(t, "run", "github.com/golangci/golangci-lint/cmd/golangci-lint@latest", "run", "./...")
 	rungo(t, "run", "github.com/golangci/golangci-lint/v2/cmd/golangci-lint@latest", "run")
 }

--- a/cmd/fetch_test.go
+++ b/cmd/fetch_test.go
@@ -63,11 +63,11 @@ func TestFetch(t *testing.T) {
 	gitService.On("GetUnidiff", "12345").Return("unidiff", nil)
 	gitService.On("Clone", mock.Anything, mock.Anything).Return(nil)
 
-	err := runFetchForTest("owner/repo", "is:pr", "/tmp", githubService, gitService)
+	err := runFetchForTest("owner/repo", "is:pr", githubService, gitService)
 	assert.NoError(t, err)
 }
 
-func runFetchForTest(repo, query, googleapisRepoPath string, githubService internal.GitHubServiceInterface, gitService internal.GitServiceInterface) error {
+func runFetchForTest(repo, query string, githubService internal.GitHubServiceInterface, gitService internal.GitServiceInterface) error {
 	log.Println("Running fetch command")
 	fmt.Printf("Fetching pull requests for repository: %s\n", repo)
 	fmt.Printf("Query: %s\n", query)


### PR DESCRIPTION
This change adds vulnerability scanning to the project by integrating `govulncheck` into the test suite.

A new test, `TestVulnerabilityCheck`, has been added to `application_test.go`. This ensures that vulnerability checks are run automatically as part of the `go test ./...` command, rather than requiring a separate CI step.

An unrelated static analysis issue (unparam) was also fixed.

Fixes: #22