### PR TITLE
feat: Add dependency check to test suite

### DIFF
--- a/cmd/fetch_test.go
+++ b/cmd/fetch_test.go
@@ -63,11 +63,11 @@ func TestFetch(t *testing.T) {
 	gitService.On("GetUnidiff", "12345").Return("unidiff", nil)
 	gitService.On("Clone", mock.Anything, mock.Anything).Return(nil)
 
-	err := runFetchForTest("owner/repo", "is:pr", "/tmp", githubService, gitService)
+	err := runFetchForTest("owner/repo", "is:pr", githubService, gitService)
 	assert.NoError(t, err)
 }
 
-func runFetchForTest(repo, query, googleapisRepoPath string, githubService internal.GitHubServiceInterface, gitService internal.GitServiceInterface) error {
+func runFetchForTest(repo, query string, githubService internal.GitHubServiceInterface, gitService internal.GitServiceInterface) error {
 	log.Println("Running fetch command")
 	fmt.Printf("Fetching pull requests for repository: %s\n", repo)
 	fmt.Printf("Query: %s\n", query)

--- a/dependencies_test.go
+++ b/dependencies_test.go
@@ -1,0 +1,23 @@
+package main_test
+
+import (
+	"flag"
+	"os/exec"
+	"testing"
+)
+
+var runIntegration = flag.Bool("integration", false, "run integration tests")
+
+func TestDependencies(t *testing.T) {
+	if !*runIntegration {
+		t.Skip("skipping dependency check in non-integration mode.")
+	}
+	cmd := exec.Command("go", "mod", "tidy", "-diff")
+	output, err := cmd.CombinedOutput()
+	if err != nil {
+		t.Fatalf("go mod tidy -diff failed: %v\n%s", err, output)
+	}
+	if len(output) > 0 {
+		t.Errorf("go mod tidy -diff produced output, meaning the go.mod and go.sum files are not up-to-date:\n%s", output)
+	}
+}


### PR DESCRIPTION
This change adds a new test that runs `go mod tidy -diff` to ensure that the `go.mod` and `go.sum` files are up-to-date. This will help to prevent issues with out-of-date dependencies.

A new `-integration` flag has been added to control the execution of this test.

Fixes: #21